### PR TITLE
Remove unquote_plus

### DIFF
--- a/src/fhirpath/search.py
+++ b/src/fhirpath/search.py
@@ -206,7 +206,6 @@ class SearchContext(object):
         normalized_values = []
         if not raw_value:
             return []
-
         elif isinstance(raw_value, list):
             bucket: List[str] = list()
             for rv in raw_value:
@@ -388,7 +387,7 @@ class Search(object):
             parts = q.split("=")
             param_name = unquote_plus(parts[0])
             try:
-                value = parts[1] and unquote_plus(parts[1]) or None
+                value = parts[1] or None
             except IndexError:
                 if not allow_none:
                     continue


### PR DESCRIPTION
Fixes https://github.com/arkhn/warehouse-api/issues/181

I'm not sure why this function was used (our pyfhirstore tests still work without it) and it was removing the `+` in instant timezones (for instance `2013-12-10T09:00:00+02:00` was turned to `2013-12-10T09:00:00 02:00`)